### PR TITLE
Added Support for zabbix agent 2 and minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ This template was tested on:
 
 - Copy content or download `apt_upgrade_agent_script.sh` script and move into host folder (Example): /etc/zabbix/custom_scripts
 
-	 `wget https://github.com/Moluss/zabbix-template-apt-upgrade-monitoring/tree/main/agent_scripts` 
+	 `sudo wget https://raw.githubusercontent.com/AkuLink1/zabbix-template-apt-upgrade-monitoring/main/agent_scripts/apt_upgrade_agent_script.sh` 
  
 - Grant exec permissions 
 
-     `sudo chmod +x /etc/zabbix/custom_scripts/apt_upgrade_agent_script`
+     `sudo chmod +x /etc/zabbix/custom_scripts/apt_upgrade_agent_script.sh`
 
 - Add entry to crontab (`sudo crontab -e`) to execute the script periodically to check for updates and then check for possible upgrades and send data to Zabbix Server. This cron will run every 12 hours:
 

--- a/agent_scripts/apt_upgrade_agent_2_script.sh
+++ b/agent_scripts/apt_upgrade_agent_2_script.sh
@@ -19,11 +19,11 @@ if [ -z "$ZBX_SERVER" ]; then
 fi
 
 # Get hostname
-ZBX_HOSTNAMEITEM_PRESENT=$(egrep ^HostnameItem /etc/zabbix/zabbix_agent2.conf -c)
+ZBX_HOSTNAMEITEM_PRESENT=$(egrep ^HostnameItem $AGENTD_CONF_FILE -c)
 if [ "$ZBX_HOSTNAMEITEM_PRESENT" -ge "1" ]; then
         ZBX_HOSTNAME=$(hostname)
 else
-        ZBX_HOSTNAME=$(egrep ^Hostname /etc/zabbix/zabbix_agent2.conf | cut -d = -f 2)
+        ZBX_HOSTNAME=$(egrep ^Hostname $AGENTD_CONF_FILE | cut -d = -f 2)
 fi
 
 #######

--- a/agent_scripts/apt_upgrade_agent_2_script.sh
+++ b/agent_scripts/apt_upgrade_agent_2_script.sh
@@ -12,7 +12,7 @@ TEMP_ZBX_FILE=/tmp/zabbix_apt_check_output.tmp
 echo -n "" > $TEMP_ZBX_FILE
 
 # Check if Server IP/name is set in configuration file
-ZBX_SERVER=$(egrep ^Server= $AGENTD_CONF_FILE | cut -d = -f 2)
+ZBX_SERVER=$(egrep ^Server= $AGENTD_CONF_FILE | cut -d = -f 2 | head -n 1)
 if [ -z "$ZBX_SERVER" ]; then
    echo "Server is not set in zabbix_agent2.conf file"
    exit -1

--- a/agent_scripts/apt_upgrade_agent_2_script.sh
+++ b/agent_scripts/apt_upgrade_agent_2_script.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Author:       JakobHeubl
+# Website       https://github.com/JakobHeubl
+# Description:  APT updates Monitor using Zabbix via command `apt-get -s upgrade`
+# Forked from:  https://github.com/AkuLink1/zabbix-template-apt-upgrade-monitoring
+
+# Server configuration file route
+AGENTD_CONF_FILE=/etc/zabbix/zabbix_agent2.conf
+
+# Route for tmp file to store yum output
+TEMP_ZBX_FILE=/tmp/zabbix_apt_check_output.tmp
+echo -n "" > $TEMP_ZBX_FILE
+
+# Check if Server IP/name is set in configuration file
+ZBX_SERVER=$(egrep ^Server= $AGENTD_CONF_FILE | cut -d = -f 2)
+if [ -z "$ZBX_SERVER" ]; then
+   echo "Server is not set in zabbix_agentd.conf file"
+   exit -1
+fi
+
+# Get hostname
+ZBX_HOSTNAMEITEM_PRESENT=$(egrep ^HostnameItem /etc/zabbix/zabbix_agent2.conf -c)
+if [ "$ZBX_HOSTNAMEITEM_PRESENT" -ge "1" ]; then
+        ZBX_HOSTNAME=$(hostname)
+else
+        ZBX_HOSTNAME=$(egrep ^Hostname /etc/zabbix/zabbix_agent2.conf | cut -d = -f 2)
+fi
+
+#######
+# APT Update + Upgrade info
+#######
+UPDATE_PACKAGES=$(apt-get update)
+APT_UPGRADE_SIMULATION=$(apt-get -s upgrade)
+
+# Kept Back Packages: An already installed package now needs to install more new package as dependency. When you manually and individually update these packages, you see what new packages are going to be installed and the error is not shown anymore.
+PACKAGES_KEPT_BACK_COUNT=$(echo $APT_UPGRADE_SIMULATION | grep -o "[[:digit:]]\+ not upgraded" | grep -o "[[:digit:]]\+")
+PACKAGES_KEPT_BACK_DESCRIPTION=$(echo $APT_UPGRADE_SIMULATION | grep -A1 "packages have been kept back:" || echo "No packages were kept back")
+
+# Ready to Upgrade Packages: Packages will be installed
+PACKAGES_READY_TO_UPDATE_COUNT=$(echo $APT_UPGRADE_SIMULATION | grep -o "[[:digit:]]\+ upgraded" | grep -o "[[:digit:]]\+")
+PACKAGES_READY_TO_UPDATE_DESCRIPTION=$(echo $APT_UPGRADE_SIMULATION | grep -A1 "will be upgraded:" || echo "No packages to upgrade")
+
+# Newly installed
+PACKAGES_NEWLY_INSTALLED_COUNT=$(echo $APT_UPGRADE_SIMULATION | grep -o "[[:digit:]]\+ newly installed" | grep -o "[[:digit:]]\+")
+PACKAGES_NEWLY_INSTALLED_DESCRIPTION=$(echo $APT_UPGRADE_SIMULATION | grep -A1 "NEW packages will be installed" || echo "No new packages to install")
+
+# To remove
+PACKAGES_TO_REMOVE_COUNT=$(echo $APT_UPGRADE_SIMULATION | grep -o "[[:digit:]]\+ to remove" | grep -o "[[:digit:]]\+")
+PACKAGES_TO_REMOVE_DESCRIPTION=$(echo $APT_UPGRADE_SIMULATION | grep -A1 "are no longer required" || echo "No packages to remove")
+
+# Total count summed up
+TOTAL_PACKAGES_COUNT=`expr $PACKAGES_KEPT_BACK_COUNT + $PACKAGES_READY_TO_UPDATE_COUNT + $PACKAGES_NEWLY_INSTALLED_COUNT + $PACKAGES_TO_REMOVE_COUNT`
+# APT Upgrade Summary
+APT_UPGRADE_SUMMARY=$(echo "$APT_UPGRADE_SIMULATION" | grep "[[:digit:]]\+ upgraded")
+
+########
+# Add to tmp file and send to Zabbix Server
+########
+# Apt Upgrade Full Summary
+echo -n "\"$ZBX_HOSTNAME\" apt.packagesupgradesummary.count $TOTAL_PACKAGES_COUNT\n" >> $TEMP_ZBX_FILE
+echo -n "\"$ZBX_HOSTNAME\" apt.packagesupgradesummary.description $APT_UPGRADE_SUMMARY\n" >> $TEMP_ZBX_FILE
+
+# Kept Back Packages
+echo -n "\"$ZBX_HOSTNAME\" apt.keptbackupdates.description $PACKAGES_KEPT_BACK_DESCRIPTION\n" >> $TEMP_ZBX_FILE
+
+# Kept Back Packages
+echo -n "\"$ZBX_HOSTNAME\" apt.newlyinstalled.description $PACKAGES_NEWLY_INSTALLED_DESCRIPTION\n" >> $TEMP_ZBX_FILE
+
+# Ready to Upgrade Packages
+echo -n "\"$ZBX_HOSTNAME\" apt.readytoupgrade.description $PACKAGES_READY_TO_UPDATE_DESCRIPTION\n" >> $TEMP_ZBX_FILE
+
+# Ready to Upgrade Packages
+echo -n "\"$ZBX_HOSTNAME\" apt.toremove.description $PACKAGES_TO_REMOVE_DESCRIPTION\n" >> $TEMP_ZBX_FILE
+
+# OS Release Number
+zabbix_sender -z $ZBX_SERVER -i $TEMP_ZBX_FILE

--- a/agent_scripts/apt_upgrade_agent_2_script.sh
+++ b/agent_scripts/apt_upgrade_agent_2_script.sh
@@ -12,7 +12,7 @@ TEMP_ZBX_FILE=/tmp/zabbix_apt_check_output.tmp
 echo -n "" > $TEMP_ZBX_FILE
 
 # Check if Server IP/name is set in configuration file
-ZBX_SERVER=$(egrep ^Server= $AGENTD_CONF_FILE | cut -d = -f 2 | head -n 1)
+ZBX_SERVER=$(egrep ^Server $AGENTD_CONF_FILE | cut -d = -f 2 | head -n 1)
 if [ -z "$ZBX_SERVER" ]; then
    echo "Server is not set in zabbix_agent2.conf file"
    exit -1

--- a/agent_scripts/apt_upgrade_agent_2_script.sh
+++ b/agent_scripts/apt_upgrade_agent_2_script.sh
@@ -14,7 +14,7 @@ echo -n "" > $TEMP_ZBX_FILE
 # Check if Server IP/name is set in configuration file
 ZBX_SERVER=$(egrep ^Server= $AGENTD_CONF_FILE | cut -d = -f 2)
 if [ -z "$ZBX_SERVER" ]; then
-   echo "Server is not set in zabbix_agentd.conf file"
+   echo "Server is not set in zabbix_agent2.conf file"
    exit -1
 fi
 

--- a/agent_scripts/apt_upgrade_agent_2_script.sh
+++ b/agent_scripts/apt_upgrade_agent_2_script.sh
@@ -8,7 +8,11 @@
 AGENTD_CONF_FILE=/etc/zabbix/zabbix_agent2.conf
 
 # Route for tmp file to store yum output
-TEMP_ZBX_FILE=/tmp/zabbix_apt_check_output.tmp
+TEMP_ZBX_FILE=/tmp/zabbix/zabbix_apt_check_output.tmp
+
+# Create folder if not exists
+mkdir -p /tmp/zabbix
+
 echo -n "" > $TEMP_ZBX_FILE
 
 # Check if Server IP/name is set in configuration file

--- a/agent_scripts/apt_upgrade_agent_script.sh
+++ b/agent_scripts/apt_upgrade_agent_script.sh
@@ -2,7 +2,7 @@
 # Author:       AkuLink1
 # Website       https://github.com/AkuLink1
 # Description:  APT updates Monitor using Zabbix via command `apt-get -s upgrade`
-#
+# Forked from:  https://github.com/AkuLink1/zabbix-template-apt-upgrade-monitoring
 
 # Server configuration file route
 AGENTD_CONF_FILE=/etc/zabbix/zabbix_agentd.conf

--- a/agent_scripts/apt_upgrade_agent_script.sh
+++ b/agent_scripts/apt_upgrade_agent_script.sh
@@ -19,11 +19,11 @@ if [ -z "$ZBX_SERVER" ]; then
 fi
 
 # Get hostname
-ZBX_HOSTNAMEITEM_PRESENT=$(egrep ^HostnameItem /etc/zabbix/zabbix_agentd.conf -c)
+ZBX_HOSTNAMEITEM_PRESENT=$(egrep ^HostnameItem $AGENTD_CONF_FILE -c)
 if [ "$ZBX_HOSTNAMEITEM_PRESENT" -ge "1" ]; then
         ZBX_HOSTNAME=$(hostname)
 else
-        ZBX_HOSTNAME=$(egrep ^Hostname /etc/zabbix/zabbix_agentd.conf | cut -d = -f 2)
+        ZBX_HOSTNAME=$(egrep ^Hostname $AGENTD_CONF_FILE | cut -d = -f 2)
 fi
 
 #######

--- a/agent_scripts/apt_upgrade_agent_script.sh
+++ b/agent_scripts/apt_upgrade_agent_script.sh
@@ -12,7 +12,7 @@ TEMP_ZBX_FILE=/tmp/zabbix_apt_check_output.tmp
 echo -n "" > $TEMP_ZBX_FILE
 
 # Check if Server IP/name is set in configuration file
-ZBX_SERVER=$(egrep ^Server $AGENTD_CONF_FILE | cut -d = -f 2)
+ZBX_SERVER=$(egrep ^Server $AGENTD_CONF_FILE | cut -d = -f 2 | head -n 1)
 if [ -z "$ZBX_SERVER" ]; then
    echo "Server is not set in zabbix_agentd.conf file"
    exit -1

--- a/agent_scripts/apt_upgrade_agent_script.sh
+++ b/agent_scripts/apt_upgrade_agent_script.sh
@@ -9,6 +9,9 @@ AGENTD_CONF_FILE=/etc/zabbix/zabbix_agentd.conf
 
 # Route for tmp file to store yum output
 TEMP_ZBX_FILE=/tmp/zabbix_apt_check_output.tmp
+# Create folder if not exists
+mkdir -p /tmp/zabbix
+
 echo -n "" > $TEMP_ZBX_FILE
 
 # Check if Server IP/name is set in configuration file


### PR DESCRIPTION
Hey there, 
i added support for the newer zabbix agent 2 by creating a new sh file.
The template for the zabbix server does not need any changes.

I tested it with:
- Zabbix Server 6.2.9
- Debian 10
- Zabbix Sender 6.2.9
- Zabix Agent 2 

I also updated the Readme to the new file locations and made minor changes to make the installation easier.

Cheers!